### PR TITLE
enable / disable securty system

### DIFF
--- a/accessories/smartWater.js
+++ b/accessories/smartWater.js
@@ -4,8 +4,7 @@ const FLO_VALVE_OPEN = 'open';
 const FLO_VALVE_CLOSE = 'closed';
 
 class FloSmartWater {
- 
- constructor(flo, device, log, config, Service, Characteristic, UUIDGen, deviceIndex) {
+  constructor(flo, device, log, config, Service, Characteristic, UUIDGen, deviceIndex, enableSecuritySystem) {
     this.Characteristic = Characteristic;
     this.Service = Service;
     this.log = log;
@@ -16,6 +15,7 @@ class FloSmartWater {
     this.location = device.location;
     this.version = device.version;
     this.isInstalled = device.isInstalled;
+    this.enableSecuritySystem = enableSecuritySystem !== undefined ? enableSecuritySystem : true; // Default to true for compatibility
 
     this.deviceid = device.deviceid.toString();
     this.uuid = UUIDGen.generate(this.deviceid);
@@ -53,12 +53,21 @@ class FloSmartWater {
       [Characteristic.SecuritySystemTargetState.AWAY_ARM]: 'away',
     };
 
-    this.VALID_CURRENT_STATE_VALUES = [Characteristic.SecuritySystemCurrentState.STAY_ARM, Characteristic.SecuritySystemCurrentState.AWAY_ARM, Characteristic.SecuritySystemCurrentState.DISARMED, Characteristic.SecuritySystemCurrentState.ALARM_TRIGGERED];
-    this.VALID_TARGET_STATE_VALUES = [Characteristic.SecuritySystemTargetState.STAY_ARM, Characteristic.SecuritySystemTargetState.AWAY_ARM, Characteristic.SecuritySystemTargetState.DISARM];
+    this.VALID_CURRENT_STATE_VALUES = [
+      Characteristic.SecuritySystemCurrentState.STAY_ARM,
+      Characteristic.SecuritySystemCurrentState.AWAY_ARM,
+      Characteristic.SecuritySystemCurrentState.DISARMED,
+      Characteristic.SecuritySystemCurrentState.ALARM_TRIGGERED
+    ];
+    this.VALID_TARGET_STATE_VALUES = [
+      Characteristic.SecuritySystemTargetState.STAY_ARM,
+      Characteristic.SecuritySystemTargetState.AWAY_ARM,
+      Characteristic.SecuritySystemTargetState.DISARM
+    ];
     this.systemFault = Characteristic.StatusFault.NO_FAULT;
     this.systemTampered = Characteristic.StatusTampered.NOT_TAMPERED;
-    this.IsWarningAsCritical = config.treatWarningAsCritical ? config.treatWarningAsCritical : false;  
-    this.IsValveControlEnabled = config.enableValveControl ? config.enableValveControl : false;  
+    this.IsWarningAsCritical = config.treatWarningAsCritical ? config.treatWarningAsCritical : false;
+    this.IsValveControlEnabled = config.enableValveControl ? config.enableValveControl : false;
     this.systemCurrentState = device.systemCurrentState;
     this.systemTargetState = device.systemTargetState;
     this.valveStatus = device.valveCurrentState;
@@ -66,172 +75,192 @@ class FloSmartWater {
     this.flo.on(this.deviceid, this.refreshState.bind(this));
   }
 
-
-  refreshState(eventData)
-  {
-    this.log.debug(`Device updated requested: ` , eventData);
+  refreshState(eventData) {
+    this.log.debug(`Device updated requested: `, eventData);
     this.valveStatus = eventData.device.valveGlobalState;
     this.gallonsPerMin = eventData.device.gpm;
     this.isInstalled = eventData.device.isInstalled;
     this.pressure = eventData.device.psi;
 
-    // get security system
-    const securityService = this.accessory.getService(this.Service.SecuritySystem);
+    // Get services
     const valveService = this.accessory.getService(this.Service.Valve);
 
-    if(eventData.device.notifications.criticalCount > 0) {
-      this.systemCurrentState = 'alarm';
-    } else {
-      // Current state does not provide correct state, using TargetState
-      this.systemCurrentState = eventData.device.systemCurrentState;
-      this.systemTargetState = eventData.device.systemTargetState;
-    }
-
-    // Treat warning as critical
-    if ((eventData.device.notifications.warningCount > 0) || (eventData.device.warningCount > 0)) {
-        // Check option if warning should be escalated to alarms
-        if (this.IsWarningAsCritical)
-        {
-          this.systemCurrentState = 'alarm';
-        }
-    }
-
-    // Is device is offline?
-    if ((eventData.device.offline != 0 ) || (eventData.device.isConnected == false )) 
-    {
-      this.systemFault = this.Characteristic.StatusFault.GENERAL_FAULT;
-      this.systemTampered = this.Characteristic.StatusTampered.TAMPERED;
-    }
-    else
-    {
-      this.systemTampered = this.Characteristic.StatusTampered.NOT_TAMPERED;
-      this.systemFault = this.Characteristic.StatusFault.NO_FAULT;
-    }  
-
-  
     // Update valve state
-    valveService.updateCharacteristic(this.Characteristic.Active,this.VALVE_ACTIVE_STATE[this.valveStatus]);
-    valveService.updateCharacteristic(this.Characteristic.InUse,this.VALVE_INUSE_STATE[this.valveStatus]);
+    valveService.updateCharacteristic(this.Characteristic.Active, this.VALVE_ACTIVE_STATE[this.valveStatus]);
+    valveService.updateCharacteristic(this.Characteristic.InUse, this.VALVE_INUSE_STATE[this.valveStatus]);
 
-    //valveService.updateCharacteristic(this.Characteristic.IsConfigured,this.VALVE_CONFIGURED_STATE[this.isInstalled]);
-   
-    // Update mode state
-    securityService.updateCharacteristic(this.Characteristic.SecuritySystemCurrentState, this.CURRENT_FLO_TO_HOMEKIT[this.systemCurrentState]);
-    if(this.systemCurrentState != 'alarm') {
-      securityService.updateCharacteristic(this.Characteristic.SecuritySystemTargetState, this.TARGET_FLO_TO_HOMEKIT[this.systemTargetState]);
-      securityService.updateCharacteristic(this.Characteristic.StatusTampered, this.systemTampered);
-      valveService.updateCharacteristic(this.Characteristic.StatusFault, this.systemFault);
+    // Handle security system only if enabled
+    if (this.enableSecuritySystem) {
+      const securityService = this.accessory.getService(this.Service.SecuritySystem);
+      if (securityService) {
+        if (eventData.device.notifications.criticalCount > 0) {
+          this.systemCurrentState = 'alarm';
+        } else {
+          // Current state does not provide correct state, using TargetState
+          this.systemCurrentState = eventData.device.systemCurrentState;
+          this.systemTargetState = eventData.device.systemTargetState;
+        }
 
+        // Treat warning as critical
+        if ((eventData.device.notifications.warningCount > 0) || (eventData.device.warningCount > 0)) {
+          if (this.IsWarningAsCritical) {
+            this.systemCurrentState = 'alarm';
+          }
+        }
+
+        // Is device offline?
+        if ((eventData.device.offline != 0) || (eventData.device.isConnected == false)) {
+          this.systemFault = this.Characteristic.StatusFault.GENERAL_FAULT;
+          this.systemTampered = this.Characteristic.StatusTampered.TAMPERED;
+        } else {
+          this.systemTampered = this.Characteristic.StatusTampered.NOT_TAMPERED;
+          this.systemFault = this.Characteristic.StatusFault.NO_FAULT;
+        }
+
+        // Update mode state
+        securityService.updateCharacteristic(
+          this.Characteristic.SecuritySystemCurrentState,
+          this.CURRENT_FLO_TO_HOMEKIT[this.systemCurrentState]
+        );
+        if (this.systemCurrentState != 'alarm') {
+          securityService.updateCharacteristic(
+            this.Characteristic.SecuritySystemTargetState,
+            this.TARGET_FLO_TO_HOMEKIT[this.systemTargetState]
+          );
+          securityService.updateCharacteristic(this.Characteristic.StatusTampered, this.systemTampered);
+          valveService.updateCharacteristic(this.Characteristic.StatusFault, this.systemFault);
+        }
+      }
     }
-
   }
 
-  setAccessory(accessory)  {
+  setAccessory(accessory) {
     this.accessory = accessory;
-    this.accessory.getService(this.Service.AccessoryInformation)
-        .setCharacteristic(this.Characteristic.Manufacturer, 'Moen')
-        .setCharacteristic(this.Characteristic.Model, 'Smart Shutoff Valve - ' + this.model)
-        .setCharacteristic(this.Characteristic.SerialNumber, this.serialNumber)
-        .setCharacteristic(this.Characteristic.FirmwareRevision, this.version);
+    this.accessory
+      .getService(this.Service.AccessoryInformation)
+      .setCharacteristic(this.Characteristic.Manufacturer, 'Moen')
+      .setCharacteristic(this.Characteristic.Model, 'Smart Shutoff Valve - ' + this.model)
+      .setCharacteristic(this.Characteristic.SerialNumber, this.serialNumber)
+      .setCharacteristic(this.Characteristic.FirmwareRevision, this.version);
 
-
-    var securityService = this.accessory.getService(this.Service.SecuritySystem);
-    if(securityService == undefined) securityService = this.accessory.addService(this.Service.SecuritySystem, this.name + ' Water System');
-    securityService.setCharacteristic(this.Characteristic.Name, this.name + ' Water System'); 
-    securityService.getCharacteristic(this.Characteristic.SecuritySystemCurrentState)
+    // Security System Service (conditional)
+    if (this.enableSecuritySystem) {
+      let securityService = this.accessory.getService(this.Service.SecuritySystem);
+      if (!securityService) {
+        securityService = this.accessory.addService(this.Service.SecuritySystem, this.name + ' Water System');
+      }
+      securityService.setCharacteristic(this.Characteristic.Name, this.name + ' Water System');
+      securityService
+        .getCharacteristic(this.Characteristic.SecuritySystemCurrentState)
         .setProps({ validValues: this.VALID_CURRENT_STATE_VALUES })
         .on('get', async callback => this.getCurrentState(callback));
-        securityService.getCharacteristic(this.Characteristic.SecuritySystemTargetState)
+      securityService
+        .getCharacteristic(this.Characteristic.SecuritySystemTargetState)
         .setProps({ validValues: this.VALID_TARGET_STATE_VALUES })
         .on('get', async callback => this.getTargetState(callback))
         .on('set', async (state, callback) => this.setTargetState(state, callback));
-    securityService.setCharacteristic(this.Characteristic.StatusTampered, this.Characteristic.StatusTampered.NOT_TAMPERED);
+      securityService.setCharacteristic(
+        this.Characteristic.StatusTampered,
+        this.Characteristic.StatusTampered.NOT_TAMPERED
+      );
+    }
 
-    // create a new Valve service
-    var valveService = this.accessory.getService(this.Service.Valve);
-    if(valveService == undefined) valveService = this.accessory.addService(this.Service.Valve, this.name + ' Valve'); 
-    // create handlers for required characteristics
-    valveService.setCharacteristic(this.Characteristic.Name, this.name + ' Valve'); 
+    // Create a new Valve service
+    let valveService = this.accessory.getService(this.Service.Valve);
+    if (!valveService) {
+      valveService = this.accessory.addService(this.Service.Valve, this.name + ' Valve');
+    }
+    // Create handlers for required characteristics
+    valveService.setCharacteristic(this.Characteristic.Name, this.name + ' Valve');
     valveService.setCharacteristic(this.Characteristic.ValveType, 0);
 
     valveService.setCharacteristic(this.Characteristic.SetDuration, 0);
     valveService.setCharacteristic(this.Characteristic.RemainingDuration, 0);
-    valveService.getCharacteristic(this.Characteristic.Active)
-        .on('get', async callback => this.getValveActive(callback))
-        .on('set', async (state, callback) => this.setValveActive(state, callback));
-    valveService.getCharacteristic(this.Characteristic.InUse)
-        .on('get', async callback => this.getValveInUse(callback));
+    valveService
+      .getCharacteristic(this.Characteristic.Active)
+      .on('get', async callback => this.getValveActive(callback))
+      .on('set', async (state, callback) => this.setValveActive(state, callback));
+    valveService
+      .getCharacteristic(this.Characteristic.InUse)
+      .on('get', async callback => this.getValveInUse(callback));
     valveService.setCharacteristic(this.Characteristic.StatusFault, this.systemFault);
-    valveService.setCharacteristic(this.Characteristic.IsConfigured,this.VALVE_CONFIGURED_STATE[this.isInstalled]);
-    
-  // water temp was deprecated by FLO. If control exist removed it.
-    // Remove service if already created in cache accessory
-    var temperatureService;
-  
-    temperatureService = this.accessory.getService(this.Service.TemperatureSensor);
-    if (temperatureService!= undefined) this.accessory.removeService(temperatureService);
-    
+    valveService.setCharacteristic(
+      this.Characteristic.IsConfigured,
+      this.VALVE_CONFIGURED_STATE[this.isInstalled]
+    );
+
+    // Water temp was deprecated by FLO. If control exists, remove it.
+    let temperatureService = this.accessory.getService(this.Service.TemperatureSensor);
+    if (temperatureService) {
+      this.accessory.removeService(temperatureService);
+    }
   }
 
-
-// Handle requests to get the alarm states. Return index of alarm state
-async getCurrentState(callback) {
+  // Handle requests to get the alarm states. Return index of alarm state
+  async getCurrentState(callback) {
+    if (!this.enableSecuritySystem) {
+      return callback(new Error('Security system is disabled'));
+    }
     var currentValue = this.CURRENT_FLO_TO_HOMEKIT[this.systemCurrentState];
     return callback(null, currentValue);
   }
 
-async getTargetState(callback) {
+  async getTargetState(callback) {
+    if (!this.enableSecuritySystem) {
+      return callback(new Error('Security system is disabled'));
+    }
     var currentValue = this.TARGET_FLO_TO_HOMEKIT[this.systemTargetState];
     return callback(null, currentValue);
   }
 
-// Change smart water shutoff monitoring state.
-async setTargetState(homekitState, callback) {
-    this.flo.setSystemMode(this.location, this.TARGET_HOMEKIT_TO_FLO[homekitState],this.systemCurrentState);
+  // Change smart water shutoff monitoring state.
+  async setTargetState(homekitState, callback) {
+    if (!this.enableSecuritySystem) {
+      return callback(new Error('Security system is disabled'));
+    }
+    this.flo.setSystemMode(this.location, this.TARGET_HOMEKIT_TO_FLO[homekitState], this.systemCurrentState);
     this.systemCurrentState = this.TARGET_HOMEKIT_TO_FLO[homekitState];
     this.systemTargetState = this.TARGET_HOMEKIT_TO_FLO[homekitState];
     callback(null);
   }
 
-// Handle requests to get the current value of the "Active" characteristic
-async getValveActive(callback) {
-  this.log.debug("Trigger Get Valve Active");
-  // Assume on and disable if state is close
-  var currentValue = this.VALVE_ACTIVE_STATE[this.valveStatus];
-  return callback(null, currentValue);
-}
+  // Handle requests to get the current value of the "Active" characteristic
+  async getValveActive(callback) {
+    this.log.debug("Trigger Get Valve Active");
+    var currentValue = this.VALVE_ACTIVE_STATE[this.valveStatus];
+    return callback(null, currentValue);
+  }
 
-// Handle requests to set the "Active" characteristic
-async setValveActive(homekitState, callback) {
-  this.log.debug("Trigger Set Valve Active");
-  if (this.IsValveControlEnabled) {
-    if (homekitState == this.Characteristic.Active.ACTIVE) 
-    {  
-      this.flo.setValve(this.deviceid , FLO_VALVE_OPEN, this.deviceIndex)
-      this.valveStatus = FLO_VALVE_OPEN;
-    }
-    else {
-      this.flo.setValve(this.deviceid , FLO_VALVE_CLOSE, this.deviceIndex)
-      this.valveStatus = FLO_VALVE_CLOSE;
-    }
-  } else {
+  // Handle requests to set the "Active" characteristic
+  async setValveActive(homekitState, callback) {
+    this.log.debug("Trigger Set Valve Active");
+    if (this.IsValveControlEnabled) {
+      if (homekitState == this.Characteristic.Active.ACTIVE) {
+        this.flo.setValve(this.deviceid, FLO_VALVE_OPEN, this.deviceIndex);
+        this.valveStatus = FLO_VALVE_OPEN;
+      } else {
+        this.flo.setValve(this.deviceid, FLO_VALVE_CLOSE, this.deviceIndex);
+        this.valveStatus = FLO_VALVE_CLOSE;
+      }
+    } else {
       this.log.warn("Smart Water Shutoff: Valve control is disabled in Homebridge.");
       var valveService = this.accessory.getService(this.Service.Valve);
-      setTimeout(function () {valveService.updateCharacteristic(this.Characteristic.Active,this.VALVE_ACTIVE_STATE[this.valveStatus])}.bind(this),500);
+      setTimeout(
+        function () {
+          valveService.updateCharacteristic(this.Characteristic.Active, this.VALVE_ACTIVE_STATE[this.valveStatus]);
+        }.bind(this),
+        500
+      );
+    }
+    return callback(null);
   }
-  return callback(null);
-}
 
-// Handle requests to get the current value of the "In Use" characteristic
-async getValveInUse(callback) {
-  // var currentValue = this.Characteristic.InUse.NOT_IN_USE;
-  // set this to a valid value for In-Use base meter usage
-  this.log.debug("Trigger Get Valve In Use");
-  var currentValue = this.VALVE_INUSE_STATE[this.valveStatus];
-  return callback(null, currentValue);
+  // Handle requests to get the current value of the "In Use" characteristic
+  async getValveInUse(callback) {
+    this.log.debug("Trigger Get Valve In Use");
+    var currentValue = this.VALVE_INUSE_STATE[this.valveStatus];
+    return callback(null, currentValue);
+  }
 }
-
-}
-
 
 module.exports = FloSmartWater;

--- a/config.schema.json
+++ b/config.schema.json
@@ -35,48 +35,48 @@
           }
         }
       },
-        "disableCache": {
+      "disableCache": {
         "title": "Disable Caching of Flo Token",
         "type": "boolean",
         "default": false
       },
-        "showTemperatureAndHumidity": {
+      "showTemperatureAndHumidity": {
         "title": "Show Water Sensor Temperature and Humidity in HomeKit",
         "type": "boolean",
         "default": true,
         "description": "Display Water Sensor(s) area temperature and humidity in HomeKit."
       },
-        "enableValveControl": {
+      "enableValveControl": {
         "title": "Enable Valve Control in HomeKit",
         "type": "boolean",
         "default": false,
         "description": "Enable or disable Smart Water Shutoff within HomeKit."
       },
-        "showHealthTestSwitch": {
+      "showHealthTestSwitch": {
         "title": "Run Health Test from HomeKit",
         "type": "boolean",
         "default": false,
         "description": "Display a Health Test switch button to start a manual Health Test in Flo."
       },
-        "showAuxSwitch": {
+      "showAuxSwitch": {
         "title": "Create additional switch for turning on/off the water valve",
         "type": "boolean",
-        "default": false,
+        "default": "false",
         "description": "Display an auxiliary water on/off switch. This is useful in Apple's Home application, other Homekit applications such as Eve exposes the Flo valve for automation."
       },
-        "treatWarningAsCritical": {
+      "treatWarningAsCritical": {
         "title": "Treat Warning as Critical Events",
         "type": "boolean",
         "default": false,
         "description": "This option allows <i>Warning</i> to be treated as <i>Critical</i> events thus trigging the alarm."
       },
-       "clearOnNoLeak": {
+      "clearOnNoLeak": {
         "title": "Auto Clear Leak Detection",
         "type": "boolean",
         "default": false,
         "description": "By default the leak event remain active until it is clear within the flo system, this option allows the plug-in to auto clear when water is no longer detected."
       },
-        "deviceRefresh": {
+      "deviceRefresh": {
         "title": "Device Refresh Interval (seconds)",
         "type": "integer",
         "default": 90,
@@ -84,38 +84,33 @@
         "minimum": 15,
         "maximum": 3600
       },
-        "offlineTimeLimit": {
+      "offlineTimeLimit": {
         "title": "Offline Time Limit (hours)",
         "type": "integer",
-        "description": "Number of house with no refresh before considering device offline.",
+        "description": "Number of hours with no refresh before considering device offline.",
         "default": 4,
         "minimum": 2,
         "maximum": 24
       },
-        "sleepRevertMinutes": {
+      "sleepRevertMinutes": {
         "title": "Sleep Time",
         "type": "integer",
         "default": 120,
         "description": "Sleep Mode is a system mode that quiets all monitoring and alerting, effectively putting the Flo System to sleep. This value represents the length of time to place the system in sleep mode.",
-        "oneOf": [{
-          "title": "2 Hours",
-          "enum": [
-            120
-          ]
-        },
-        {
-          "title": "24 Hours",
-          "enum": [
-           1440
-          ]
-        },
-        {
-          "title": "72 Hours",
-          "enum": [
-            4320
-          ]
-        }
-        ] 
+        "oneOf": [
+          {
+            "title": "2 Hours",
+            "enum": [120]
+          },
+          {
+            "title": "24 Hours",
+            "enum": [1440]
+          },
+          {
+            "title": "72 Hours",
+            "enum": [4320]
+          }
+        ]
       },
       "excludedDevices": {
         "type": "array",
@@ -135,10 +130,17 @@
         "title": "Show the current Gallons Per Minute (GPM) and Water Pressure (PSI) value as lux sensors.",
         "type": "boolean",
         "default": false
+      },
+      "enableSecuritySystem": {
+        "title": "Enable Security System Accessory",
+        "type": "boolean",
+        "default": true,
+        "description": "Enable or disable the security system accessory in HomeKit."
       }
     }
   },
-  "layout": [{
+  "layout": [
+    {
       "type": "fieldset",
       "items": [
         "name",
@@ -150,7 +152,8 @@
         "showHealthTestSwitch",
         "enableValveControl",
         "showAuxSwitch",
-        "offlineTimeLimit"
+        "offlineTimeLimit",
+        "enableSecuritySystem"
       ]
     },
     {
@@ -164,7 +167,6 @@
         {
           "key": "disableCache",
           "description": "Disabled the storage of Flo access token to local Homebridge server. Refresh token at start-up."
-
         },
         {
           "key": "excludedDevices",
@@ -175,9 +177,7 @@
           "items": [
             {
               "type": "fieldset",
-              "items": [
-                "excludedDevices[]"
-              ]
+              "items": ["excludedDevices[]"]
             }
           ]
         },

--- a/index.js
+++ b/index.js
@@ -5,13 +5,12 @@ const optionswitch = require('./accessories/optionSwitch');
 const floengine = require('./flomain');
 
 // Flo constants
-const FLO_WATERSENSOR ='puck_oem';
+const FLO_WATERSENSOR = 'puck_oem';
 const FLO_SMARTWATER = 'flo_device_v2';
 
 // Flo by Moen HomeBridge Plugin
 const PLUGIN_NAME = 'homebridge-flobymoen';
 const PLATFORM_NAME = 'Flo-by-Moen';
-
 
 var Accessory, Service, Characteristic, UUIDGen;
 
@@ -22,42 +21,45 @@ class FloByMoenPlatform {
     this.devices = [];
     this.accessories = [];
     this.optionalAccessories = [];
-    this.api = api;  
+    this.api = api;
     this.refreshInterval = config.deviceRefresh || 90;
     this.disableCache = config.disableCache ? config.disableCache : false;
     this.persistPath = undefined;
     this.config = config;
-    
-    
+    this.enableSecuritySystem = config.enableSecuritySystem !== undefined ? config.enableSecuritySystem : true; // Default to true for backward compatibility
 
     // Check if authentication information has been provided.
-    try{
-        if ((this.config.auth.username == "") || (this.config.auth.password == "") || (!this.config.auth.password) || (!this.config.auth.username))
-        {
-          this.log.error('Plug-in configuration error: Flo authentication information not provided.');
-          // terminate plug-in initialization
-          return;
-        }
+    try {
+      if (
+        !this.config.auth ||
+        !this.config.auth.username ||
+        !this.config.auth.password ||
+        this.config.auth.username === '' ||
+        this.config.auth.password === ''
+      ) {
+        this.log.error('Plug-in configuration error: Flo authentication information not provided.');
+        // terminate plug-in initialization
+        return;
       }
-    catch(err) {
+    } catch (err) {
       this.log.error('Plug-in configuration error: Flo authentication information not provided.');
-       // terminate plug-in initialization
+      // terminate plug-in initialization
       return;
     }
 
-    // Returns the path to the Homebridge storage folder, if local storage is enable.
+    // Returns the path to the Homebridge storage folder, if local storage is enabled.
     if (!this.disableCache) this.persistPath = api.user.persistPath();
 
-    // Create FLo engine object to interact with Flo APIs.
-    this.flo = new floengine (log, config, this.persistPath);
+    // Create Flo engine object to interact with Flo APIs.
+    this.flo = new floengine(log, config, this.persistPath);
     // Login in meetflo portal
-    this.log.info("Starting communication with Flo portal");
-    this.initialLoad = this.flo.init().then ( () => {
+    this.log.info('Starting communication with Flo portal');
+    this.initialLoad = this.flo.init().then(() => {
       this.log.debug('Initialization Successful.');
     }).catch(err => {
-              this.log.error('Flo API initialization Failure:', err);
-               // terminate plug-in initialization
-              return;
+      this.log.error('Flo API initialization Failure:', err);
+      // terminate plug-in initialization
+      return;
     });
 
     // When this event is fired it means Homebridge has restored all cached accessories from disk.
@@ -65,43 +67,53 @@ class FloByMoenPlatform {
     // in order to ensure they weren't added to homebridge already. This event can also be used
     // to start discovery of new accessories.
     api.on('didFinishLaunching', () => {
-
       // When login completes discover devices with flo account
       this.initialLoad.then(() => {
-          // Discover devices
-          if (this.flo.isLoggedIn()){
-            this.log.info("Initializing Flo devices...")
-            this.flo.discoverDevices().then (() => {
+        // Discover devices
+        if (this.flo.isLoggedIn()) {
+          this.log.info('Initializing Flo devices...');
+          this.flo.discoverDevices().then(() => {
             // Once devices are discovered update Homekit accessories
             this.refreshAccessories();
-            })
-          }
-          else
-            // User login wasn't success graceful end initialization. 
-            this.log.error("Plug-in configuration error: Flo authentication error, please review your authentication information.'")
-        })
+          });
+        } else {
+          // User login wasn't successful, gracefully end initialization.
+          this.log.error(
+            "Plug-in configuration error: Flo authentication error, please review your authentication information.'"
+          );
+        }
+      });
     });
   }
 
   // Create associates in Homekit based on devices in flo account
   async refreshAccessories() {
-  
-  // Process each flo devices and create accessories within the platform. smart water value and water sensor classes 
-  // will handle the creation and setting callback for each device types.
-  var IsHealthSwitchEnabled = this.config.showHealthTestSwitch ? this.config.showHealthTestSwitch : false;
-  var IsAuxFloSwitchEnabled = this.config.showAuxSwitch ? this.config.showAuxSwitch : false;
-  var IsGpmlux =  this.config.showGPMPSIasLight ? this.config.showGPMPSIasLight : false;
-  var IsPSIlux =  this.config.showGPMPSIasLight ? this.config.showGPMPSIasLight : false;
-  var lwatersensor = 0;
+    // Process each flo devices and create accessories within the platform. smart water valve and water sensor classes
+    // will handle the creation and setting callback for each device types.
+    var IsHealthSwitchEnabled = this.config.showHealthTestSwitch ? this.config.showHealthTestSwitch : false;
+    var IsAuxFloSwitchEnabled = this.config.showAuxSwitch ? this.config.showAuxSwitch : false;
+    var IsGpmlux = this.config.showGPMPSIasLight ? this.config.showGPMPSIasLight : false;
+    var IsPSIlux = this.config.showGPMPSIasLight ? this.config.showGPMPSIasLight : false;
+    var lwatersensor = 0;
 
-  if (this.flo.flo_devices.length <=0 ) return;
-  for (var i = 0; i < this.flo.flo_devices.length; i++) {
-    let currentDevice = this.flo.flo_devices[i];
-    switch (currentDevice.type) {
+    if (this.flo.flo_devices.length <= 0) return;
+    for (var i = 0; i < this.flo.flo_devices.length; i++) {
+      let currentDevice = this.flo.flo_devices[i];
+      switch (currentDevice.type) {
         case FLO_SMARTWATER:
-          var smartWaterAccessory = new smartwater(this.flo, currentDevice, this.log, this.config, Service, Characteristic, UUIDGen, i);
+          var smartWaterAccessory = new smartwater(
+            this.flo,
+            currentDevice,
+            this.log,
+            this.config,
+            Service,
+            Characteristic,
+            UUIDGen,
+            i,
+            this.enableSecuritySystem // Pass enableSecuritySystem to smartwater
+          );
           // check the accessory was not restored from cache
-          var foundAccessory = this.accessories.find(accessory => accessory.UUID === smartWaterAccessory.uuid)
+          var foundAccessory = this.accessories.find(accessory => accessory.UUID === smartWaterAccessory.uuid);
           if (!foundAccessory) {
             // create a new accessory
             let newAccessory = new this.api.platformAccessory(smartWaterAccessory.name, smartWaterAccessory.uuid);
@@ -109,141 +121,216 @@ class FloByMoenPlatform {
             smartWaterAccessory.setAccessory(newAccessory);
             // register the accessory
             this.addAccessory(smartWaterAccessory);
-          }
-          else // accessory already exist just set characteristic
+          } else {
+            // accessory already exists, just set characteristic
             smartWaterAccessory.setAccessory(foundAccessory);
-         
-          if(IsHealthSwitchEnabled) {
-              this.config.switchType = "healthswitch";
-              var healthswitch = new optionswitch(this.flo, currentDevice, this.log, this.config, Service, Characteristic, UUIDGen, i);
-              // check the accessory was not restored from cache
-              var foundAccessory = this.accessories.find(accessory => accessory.UUID === healthswitch.uuid)
-              if (!foundAccessory) {
-                // create a new accessory
-                let newAccessory = new this.api.platformAccessory(currentDevice.name + " Health Test", healthswitch.uuid);
-                // add services and Characteristic
-                healthswitch.setAccessory(newAccessory);
-                // register the accessory
-                this.addAccessory(healthswitch);
-              }
-              else // accessory already exist just set characteristic
-                healthswitch.setAccessory(foundAccessory);
-              // This a accessories not base on flo device list, track it in another list for future use.
-              this.optionalAccessories.push(healthswitch);
-              this.log.info(`Heath Switch Enabled for ${currentDevice.name}`);
           }
-          if(IsAuxFloSwitchEnabled) {
-            this.config.switchType = "auxswitch";
-            var auxfloswitch = new optionswitch(this.flo, currentDevice, this.log, this.config, Service, Characteristic, UUIDGen, i);
+
+          if (IsHealthSwitchEnabled) {
+            this.config.switchType = 'healthswitch';
+            var healthswitch = new optionswitch(
+              this.flo,
+              currentDevice,
+              this.log,
+              this.config,
+              Service,
+              Characteristic,
+              UUIDGen,
+              i
+            );
             // check the accessory was not restored from cache
-            var foundAccessory = this.accessories.find(accessory => accessory.UUID === auxfloswitch.uuid)
+            var foundAccessory = this.accessories.find(accessory => accessory.UUID === healthswitch.uuid);
             if (!foundAccessory) {
               // create a new accessory
-              let newAccessory = new this.api.platformAccessory(currentDevice.name + " Water Control", auxfloswitch.uuid);
+              let newAccessory = new this.api.platformAccessory(
+                currentDevice.name + ' Health Test',
+                healthswitch.uuid
+              );
+              // add services and Characteristic
+              healthswitch.setAccessory(newAccessory);
+              // register the accessory
+              this.addAccessory(healthswitch);
+            } else {
+              // accessory already exists, just set characteristic
+              healthswitch.setAccessory(foundAccessory);
+            }
+            // This is an accessory not based on flo device list, track it in another list for future use.
+            this.optionalAccessories.push(healthswitch);
+            this.log.info(`Health Switch Enabled for ${currentDevice.name}`);
+          }
+          if (IsAuxFloSwitchEnabled) {
+            this.config.switchType = 'auxswitch';
+            var auxfloswitch = new optionswitch(
+              this.flo,
+              currentDevice,
+              this.log,
+              this.config,
+              Service,
+              Characteristic,
+              UUIDGen,
+              i
+            );
+            // check the accessory was not restored from cache
+            var foundAccessory = this.accessories.find(accessory => accessory.UUID === auxfloswitch.uuid);
+            if (!foundAccessory) {
+              // create a new accessory
+              let newAccessory = new this.api.platformAccessory(
+                currentDevice.name + ' Water Control',
+                auxfloswitch.uuid
+              );
               // add services and Characteristic
               auxfloswitch.setAccessory(newAccessory);
               // register the accessory
               this.addAccessory(auxfloswitch);
-            }
-            else // accessory already exist just set characteristic
+            } else {
+              // accessory already exists, just set characteristic
               auxfloswitch.setAccessory(foundAccessory);
-            // This a accessories not base on flo device list, track it in another list for future use.
+            }
+            // This is an accessory not based on flo device list, track it in another list for future use.
             this.optionalAccessories.push(auxfloswitch);
             this.log.info(`Water Shutoff Auxiliary Switch Enabled for ${currentDevice.name}`);
           }
 
-          if(IsPSIlux) {
-            this.config.switchType = "pSIlux";
-            var pSIluxsensor = new optionswitch(this.flo, currentDevice, this.log, this.config, Service, Characteristic, UUIDGen, i);
+          if (IsPSIlux) {
+            this.config.switchType = 'pSIlux';
+            var pSIluxsensor = new optionswitch(
+              this.flo,
+              currentDevice,
+              this.log,
+              this.config,
+              Service,
+              Characteristic,
+              UUIDGen,
+              i
+            );
             // check the accessory was not restored from cache
-            var foundAccessory = this.accessories.find(accessory => accessory.UUID === pSIluxsensor.uuid)
+            var foundAccessory = this.accessories.find(accessory => accessory.UUID === pSIluxsensor.uuid);
             if (!foundAccessory) {
               // create a new accessory
-              let newAccessory = new this.api.platformAccessory(currentDevice.name + " PSI Sensors", pSIluxsensor.uuid);
+              let newAccessory = new this.api.platformAccessory(
+                currentDevice.name + ' PSI Sensors',
+                pSIluxsensor.uuid
+              );
               // add services and Characteristic
               pSIluxsensor.setAccessory(newAccessory);
               // register the accessory
               this.addAccessory(pSIluxsensor);
-            }
-            else // accessory already exist just set characteristic
+            } else {
+              // accessory already exists, just set characteristic
               pSIluxsensor.setAccessory(foundAccessory);
-            // This a accessories not base on flo device list, track it in another list for future use.
+            }
+            // This is an accessory not based on flo device list, track it in another list for future use.
             this.optionalAccessories.push(pSIluxsensor);
           }
-          if(IsGpmlux) {
-            this.config.switchType = "gpmlux";
-            var gpmluxsensor = new optionswitch(this.flo, currentDevice, this.log, this.config, Service, Characteristic, UUIDGen, i);
+          if (IsGpmlux) {
+            this.config.switchType = 'gpmlux';
+            var gpmluxsensor = new optionswitch(
+              this.flo,
+              currentDevice,
+              this.log,
+              this.config,
+              Service,
+              Characteristic,
+              UUIDGen,
+              i
+            );
             // check the accessory was not restored from cache
-            var foundAccessory = this.accessories.find(accessory => accessory.UUID === gpmluxsensor.uuid)
+            var foundAccessory = this.accessories.find(accessory => accessory.UUID === gpmluxsensor.uuid);
             if (!foundAccessory) {
               // create a new accessory
-              let newAccessory = new this.api.platformAccessory(currentDevice.name + " GPM Sensors", gpmluxsensor.uuid);
+              let newAccessory = new this.api.platformAccessory(
+                currentDevice.name + ' GPM Sensors',
+                gpmluxsensor.uuid
+              );
               // add services and Characteristic
               gpmluxsensor.setAccessory(newAccessory);
               // register the accessory
               this.addAccessory(gpmluxsensor);
-            }
-            else // accessory already exist just set characteristic
+            } else {
+              // accessory already exists, just set characteristic
               gpmluxsensor.setAccessory(foundAccessory);
-            // This a accessories not base on flo device list, track it in another list for future use.
+            }
+            // This is an accessory not based on flo device list, track it in another list for future use.
             this.optionalAccessories.push(gpmluxsensor);
           }
-          if(IsPSIlux || IsGpmlux) 
-            this.log.info(`${currentDevice.name} water valve configured. Monitoring Lux senssors are Eneabled and Homebridge control is ${this.config.enableValveControl ? 'Enabled' : 'Disabled'}`);
-          else
-            this.log.info(`${currentDevice.name} water valve configured. Homebridge control is ${this.config.enableValveControl ? 'Enabled' : 'Disabled'}`);
-         break; 
-        
-        case FLO_WATERSENSOR: 
-          var waterAccessory = new watersensor(this.flo, currentDevice, this.log, this.config, Service, Characteristic, UUIDGen);
-          // check the accessory was not restored from cache
-          var foundAccessory = this.accessories.find(accessory => accessory.UUID === waterAccessory.uuid)
-          if (!foundAccessory) {
-              // create a new accessory
-              let newAccessory = new this.api.platformAccessory(waterAccessory.name, waterAccessory.uuid);
-              // add services and Characteristic
-              waterAccessory.setAccessory(newAccessory);
-              // register the accessory
-              this.addAccessory(waterAccessory);
+          if (IsPSIlux || IsGpmlux) {
+            this.log.info(
+              `${currentDevice.name} water valve configured. Monitoring Lux sensors are Enabled and Homebridge control is ${
+                this.config.enableValveControl ? 'Enabled' : 'Disabled'
+              }`
+            );
+          } else {
+            this.log.info(
+              `${currentDevice.name} water valve configured. Homebridge control is ${
+                this.config.enableValveControl ? 'Enabled' : 'Disabled'
+              }`
+            );
           }
-          else // accessory already exist just set characteristic
+          break;
+
+        case FLO_WATERSENSOR:
+          var waterAccessory = new watersensor(
+            this.flo,
+            currentDevice,
+            this.log,
+            this.config,
+            Service,
+            Characteristic,
+            UUIDGen
+          );
+          // check the accessory was not restored from cache
+          var foundAccessory = this.accessories.find(accessory => accessory.UUID === waterAccessory.uuid);
+          if (!foundAccessory) {
+            // create a new accessory
+            let newAccessory = new this.api.platformAccessory(waterAccessory.name, waterAccessory.uuid);
+            // add services and Characteristic
+            waterAccessory.setAccessory(newAccessory);
+            // register the accessory
+            this.addAccessory(waterAccessory);
+          } else {
+            // accessory already exists, just set characteristic
             waterAccessory.setAccessory(foundAccessory);
-            lwatersensor = lwatersensor + 1;
-        break;
-       }
+          }
+          lwatersensor = lwatersensor + 1;
+          break;
+      }
     }
-    if(lwatersensor > 0) this.log.info(`${lwatersensor} Water sensor(s) discovered and configured.`);
+    if (lwatersensor > 0) this.log.info(`${lwatersensor} Water sensor(s) discovered and configured.`);
     // Clean accessories with no association with Flo devices.
     this.orphanAccessory();
-  
-    this.log.info(`Flo device updates complete, background polling process started.\nDevice will be polled each ${Math.floor((this.refreshInterval / 60))} min(s) ${Math.floor((this.refreshInterval % 60))} second(s).`);     
-   
+
+    this.log.info(
+      `Flo device updates complete, background polling process started.\nDevice will be polled each ${Math.floor(
+        this.refreshInterval / 60
+      )} min(s) ${Math.floor(this.refreshInterval % 60)} second(s).`
+    );
+
     // Start background process to poll devices.
     this.flo.startPollingProcess();
   }
 
-  //Add accessory to homekit dashboard
+  // Add accessory to homekit dashboard
   addAccessory(device) {
-
     this.log.debug('Add accessory');
-        try {
-          this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [device.accessory]);
-          this.accessories.push(device.accessory);
-        } catch (err) {
-            this.log.error(`Flo load Error: An error occurred while adding accessory: ${err}`);
-        }
+    try {
+      this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [device.accessory]);
+      this.accessories.push(device.accessory);
+    } catch (err) {
+      this.log.error(`Flo load Error: An error occurred while adding accessory: ${err}`);
+    }
   }
 
-  //Remove accessory to homekit dashboard
+  // Remove accessory from homekit dashboard
   removeAccessory(accessory, updateIndex) {
-      this.log.warn('Removing Flo accessory:',accessory.displayName );
-      if (accessory) {
-          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+    this.log.warn('Removing Flo accessory:', accessory.displayName);
+    if (accessory) {
+      this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+    }
+    if (updateIndex) {
+      if (this.accessories.indexOf(accessory) > -1) {
+        this.accessories.splice(this.accessories.indexOf(accessory), 1);
       }
-      if (updateIndex) {
-        if (this.accessories.indexOf(accessory) > -1) {
-            this.accessories.splice(this.accessories.indexOf(accessory), 1);
-      }}
+    }
   }
 
   // Find accessory with no association with Flo device and remove
@@ -251,16 +338,17 @@ class FloByMoenPlatform {
     var cachedAccessory = this.accessories;
     var foundAccessory;
 
-    for (var i = 0; i < cachedAccessory.length; i++) 
-    {   
+    for (var i = 0; i < cachedAccessory.length; i++) {
       let accessory = cachedAccessory[i];
       // determine if accessory is currently a device in flo system, thus should remain
-      foundAccessory = this.flo.flo_devices.find(device => UUIDGen.generate(device.deviceid.toString()) === accessory.UUID)
+      foundAccessory = this.flo.flo_devices.find(
+        device => UUIDGen.generate(device.deviceid.toString()) === accessory.UUID
+      );
       if (!foundAccessory) {
-        // determine if an optional components, thus should remain
+        // determine if an optional component, thus should remain
         foundAccessory = this.optionalAccessories.find(optionalAccessory => optionalAccessory.uuid === accessory.UUID);
         if (!foundAccessory) {
-            this.removeAccessory(accessory,false);
+          this.removeAccessory(accessory, false);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "water detector",
     "water sensor"
   ],
-  "author": "Haywirecoder",
+  "author": "moshsom",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/moshsom/homebridge-flobymoen-optional-securityissues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-flobymoen",
-  "displayName": "Homebridge Flo by Moen",
+  "displayName": "Homebridge Flo by Moen - security enable/disable",
   "version": "1.0.0",
   "description": "A Homebridge plugin for the Flo by Moen system",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-flobymoen",
   "displayName": "Homebridge Flo by Moen - security enable/disable",
   "version": "1.0.0",
-  "description": "A Homebridge plugin for the Flo by Moen system",
+  "description": "A Homebridge plugin for the Flo by Moen system - optional securty system",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-flobymoen",
   "displayName": "Homebridge Flo by Moen",
-  "version": "1.0.18",
+  "version": "1.0.0",
   "description": "A Homebridge plugin for the Flo by Moen system",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/haywirecoder/homebridge-flobymoen"
+    "url": "https://github.com/moshsom/homebridge-flobymoen-optional-security"
   },
   "engines": {
     "node": ">=18.12.0",
@@ -27,9 +27,9 @@
   "author": "Haywirecoder",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/haywirecoder/homebridge-flobymoen/issues"
+    "url": "https://github.com/moshsom/homebridge-flobymoen-optional-securityissues"
   },
-  "homepage": "https://github.com/haywirecoder/homebridge-flobymoen#readme",
+  "homepage": "https://github.com/moshsom/homebridge-flobymoen-optional-security#readme",
   "dependencies": {
     "axios": "^1.7.7",
     "node-persist": "^3.1.0"


### PR DESCRIPTION
I really just wanted control of the flo valve itself in home, not the security system accessory portion. I modified the code to enable / disable the security accessory from the plugin config page. It is enabled by default to keep with the spirit of the plugin. However you can now toggle it off if wanted. I've never done this before, so hopefully this is OK. I didn't know how to exclude package.json (I edited it for my testing purposes / disabled your plugin while testing) Thanks for your great work!